### PR TITLE
Add object pass through function to transforms

### DIFF
--- a/src/transform/handler.js
+++ b/src/transform/handler.js
@@ -5,6 +5,7 @@
 // robust against file changes and additions
 
 const {arrays} = require('./arrays')
+const {objects} = require('./objects')
 const {codes} = require('./codes')
 const {dates} = require('./dates')
 const {primitives} = require('./primitives')
@@ -12,7 +13,7 @@ const {tests} = require('./tests')
 
 const transform = {}
 
-Object.assign(transform, arrays, codes, dates, primitives)
+Object.assign(transform, arrays, objects, codes, dates, primitives)
 
 if (process.env.NODE_ENV === 'test') {
   Object.assign(transform, tests)

--- a/src/transform/objects.js
+++ b/src/transform/objects.js
@@ -1,14 +1,10 @@
 'use strict'
 
 exports.objects = {
-  // When mapping data, the top level object is passed through as is 
-  // instead of nesting it in the toObject. This function is useful so 
+  // When mapping data, the top level object is passed through as is
+  // instead of nesting it in the toObject. This function is useful so
   // as not to have to copy each field over manually
-  passThroughObject: function(
-    fromValue,
-    _fromObject,
-    toObject
-  ) {
+  passThroughObject: function(fromValue, _fromObject, toObject) {
     Object.assign(toObject, fromValue)
   }
 }

--- a/src/transform/objects.js
+++ b/src/transform/objects.js
@@ -1,0 +1,14 @@
+'use strict'
+
+exports.objects = {
+  // When mapping data, the top level object is passed through as is 
+  // instead of nesting it in the toObject. This function is useful so 
+  // as not to have to copy each field over manually
+  passThroughObject: function(
+    fromValue,
+    _fromObject,
+    toObject
+  ) {
+    Object.assign(toObject, fromValue)
+  }
+}

--- a/test/transformationsTest.js
+++ b/test/transformationsTest.js
@@ -389,11 +389,7 @@ test.test('Transformations', t => {
       }
       const outputObject = {}
 
-      transforms['passThroughObject'](
-        inputObject,
-        null,
-        outputObject
-      )
+      transforms['passThroughObject'](inputObject, null, outputObject)
 
       t.deepEqual(outputObject, inputObject)
       t.end()
@@ -413,11 +409,7 @@ test.test('Transformations', t => {
         firstLevelField3: 3
       }
 
-      transforms['passThroughObject'](
-        inputObject,
-        null,
-        outputObject
-      )
+      transforms['passThroughObject'](inputObject, null, outputObject)
 
       t.deepEqual(outputObject, expectedObject)
       t.end()

--- a/test/transformationsTest.js
+++ b/test/transformationsTest.js
@@ -380,4 +380,47 @@ test.test('Transformations', t => {
       t.end()
     })
   })
+
+  t.test('passThroughObject()', t => {
+    t.test('input object should equal output object', t => {
+      const inputObject = {
+        firstLevelField1: 1,
+        firstLevelField2: {secondLevelField: 2}
+      }
+      const outputObject = {}
+
+      transforms['passThroughObject'](
+        inputObject,
+        null,
+        outputObject
+      )
+
+      t.deepEqual(outputObject, inputObject)
+      t.end()
+    })
+
+    t.test('input object data should be added to output object data', t => {
+      const inputObject = {
+        firstLevelField1: 1,
+        firstLevelField2: {secondLevelField: 2}
+      }
+      const outputObject = {
+        firstLevelField3: 3
+      }
+      const expectedObject = {
+        firstLevelField1: 1,
+        firstLevelField2: {secondLevelField: 2},
+        firstLevelField3: 3
+      }
+
+      transforms['passThroughObject'](
+        inputObject,
+        null,
+        outputObject
+      )
+
+      t.deepEqual(outputObject, expectedObject)
+      t.end()
+    })
+  })
 })


### PR DESCRIPTION
When mapping data the mapping syntax always moves data from a highlevel
object to a nested position within the output. This is fine for
individual fields. However, if you want the entire input object pass
through as the high level output object this would be a manual process
of moving each field over to copy the input object structure.
This transform function solves this by assigning the input object to the
output object thereby keeping it on the same object level hierachy

DEB-20